### PR TITLE
Updates the sidebar navigation menus for the `central_admin`, `maintainer`, and `space_admin` templates. 

### DIFF
--- a/src/templates/central_admin/sidebar.html
+++ b/src/templates/central_admin/sidebar.html
@@ -1,51 +1,58 @@
 <section class="sidebar sidebar-collapsed">
     <div class="nav">
-    <a class="navlink" href="#">
+        <a class="navlink" href="#">
             <span class="material-symbols-outlined me-2">
                 dashboard
             </span>
             <span class="menu-text">Dashboard</span>
         </a>
-    <a class="navlink" href="{% url 'core:people_list' %}">
+        <a class="navlink" href="{% url 'core:people_list' %}">
             <span class="material-symbols-outlined me-2">
                 groups
             </span>
             <span class="menu-text">People</span>
         </a>
 
-    <a class="navlink" href="#">
+        <!-- <a class="navlink" href="#">
             <span class="material-symbols-outlined me-2">
                 tile_medium
             </span>
             <span class="menu-text">Departments</span>
-        </a>
+        </a> -->
 
-    <a class="navlink" href="#">
+        <!-- <a class="navlink" href="#">
             <span class="material-symbols-outlined me-2">
                 door_open
             </span>
             <span class="menu-text">Rooms</span>
-        </a>
+        </a> -->
 
-    <a class="navlink" href="#">
+        <!-- <a class="navlink" href="#">
             <span class="material-symbols-outlined me-2">
                 storefront
             </span>
             <span class="menu-text">Vendors</span>
-        </a>
+        </a> -->
 
-    <a class="navlink" href="#">
+        <!-- <a class="navlink" href="#">
             <span class="material-symbols-outlined me-2">
                 shopping_cart
             </span>
             <span class="menu-text">Purchases</span>
-        </a>
+        </a> -->
 
-    <a class="navlink" href="#">
+        <a class="navlink" href="#">
             <span class="material-symbols-outlined me-2">
                 report
             </span>
             <span class="menu-text">Issues</span>
+        </a>
+
+        <a class="navlink" href="#">
+            <span class="material-symbols-outlined">
+                apartment
+            </span>
+            <span class="menu-text">Spaces</span>
         </a>
 
     </div>

--- a/src/templates/maintainer/sidebar.html
+++ b/src/templates/maintainer/sidebar.html
@@ -6,28 +6,28 @@
             </span>
             <span class="menu-text">Dashboard</span>
         </a>
-    <a class="navlink" href="#">
+    <!-- <a class="navlink" href="#">
             <span class="material-symbols-outlined me-2">
                 groups
             </span>
             <span class="menu-text">People</span>
-        </a>
+        </a> -->
 
-    <a class="navlink" href="#">
+    <!-- <a class="navlink" href="#">
             <span class="material-symbols-outlined me-2">
                 tile_medium
             </span>
             <span class="menu-text">Departments</span>
-        </a>
+        </a> -->
 
-    <a class="navlink" href="#">
+    <!-- <a class="navlink" href="#">
             <span class="material-symbols-outlined me-2">
                 door_open
             </span>
             <span class="menu-text">Rooms</span>
-        </a>
+        </a> -->
 
-    <a class="navlink" href="#">
+    <!-- <a class="navlink" href="#">
             <span class="material-symbols-outlined me-2">
                 storefront
             </span>
@@ -39,7 +39,7 @@
                 shopping_cart
             </span>
             <span class="menu-text">Purchases</span>
-        </a>
+        </a> -->
 
     <a class="navlink" href="#">
             <span class="material-symbols-outlined me-2">

--- a/src/templates/space_admin/sidebar.html
+++ b/src/templates/space_admin/sidebar.html
@@ -6,40 +6,40 @@
             </span>
             <span class="menu-text">Dashboard</span>
         </a>
-    <a class="navlink" href="#">
+    <!-- <a class="navlink" href="#">
             <span class="material-symbols-outlined me-2">
                 groups
             </span>
             <span class="menu-text">People</span>
-        </a>
+        </a> -->
 
-    <a class="navlink" href="#">
+    <!-- <a class="navlink" href="#">
             <span class="material-symbols-outlined me-2">
                 tile_medium
             </span>
             <span class="menu-text">Departments</span>
-        </a>
+        </a> -->
 
-    <a class="navlink" href="#">
+    <!-- <a class="navlink" href="#">
             <span class="material-symbols-outlined me-2">
                 door_open
             </span>
             <span class="menu-text">Rooms</span>
-        </a>
+        </a> -->
 
-    <a class="navlink" href="#">
+    <!-- <a class="navlink" href="#">
             <span class="material-symbols-outlined me-2">
                 storefront
             </span>
             <span class="menu-text">Vendors</span>
-        </a>
+        </a> -->
 
-    <a class="navlink" href="#">
+    <!-- <a class="navlink" href="#">
             <span class="material-symbols-outlined me-2">
                 shopping_cart
             </span>
             <span class="menu-text">Purchases</span>
-        </a>
+        </a> -->
 
     <a class="navlink" href="#">
             <span class="material-symbols-outlined me-2">


### PR DESCRIPTION
This pull request updates the sidebar navigation menus for the `central_admin`, `maintainer`, and `space_admin` templates. The main changes involve hiding several navigation links by commenting them out and introducing a new "Spaces" menu item for central admins.

Navigation updates:

* Commented out (temporarily removed) the "Departments", "Rooms", "Vendors", and "Purchases" navigation links from the `central_admin/sidebar.html` sidebar.
* Added a new "Spaces" navigation link to the `central_admin/sidebar.html` sidebar.
* Commented out the "People", "Departments", "Rooms", "Vendors", and "Purchases" navigation links from both the `maintainer/sidebar.html` and `space_admin/sidebar.html` sidebars. [[1]](diffhunk://#diff-64dc146d0b31b7716f4d8d4946f7ef1e6e89f65fee1b2890cee45d905c4bc648L9-R30) [[2]](diffhunk://#diff-64dc146d0b31b7716f4d8d4946f7ef1e6e89f65fee1b2890cee45d905c4bc648L42-R42) [[3]](diffhunk://#diff-74fa276b18fc22c6a24a99ed8af47f4680c439c2ff7c0ea9622c8f5896fefa57L9-R42)